### PR TITLE
Add full remoteProfile response to profile object

### DIFF
--- a/src/providers/AzureActiveDirectory.php
+++ b/src/providers/AzureActiveDirectory.php
@@ -45,6 +45,7 @@ class AzureActiveDirectory extends LoginProvider
             'id' => isset($remoteProfile['objectId'])?$remoteProfile['objectId']:null,
             'email' => isset($remoteProfile['userPrincipalName'])?$remoteProfile['userPrincipalName']:null,
             'givenName' => isset($remoteProfile['givenName'])?$remoteProfile['givenName']:null,
+            'full' => $remoteProfile,
         ];
     }
 


### PR DESCRIPTION
This PR adds the full `$remoteProfile` response to the profile object under the `full` key so that more info is available during new user creation.

For example, here's all my field mapping in `social.php`

```php
 'userFieldMapping' => [
        'id' => "{{ profile.full.objectId }}",
        'email' => "{{ profile.full.mail }}",
        'username' => "{{ profile.full.mailNickname }}",
        'firstName' => "{{ profile.full.givenName }}",
        'lastName' => "{{ profile.full.surname }}",
        'department' => "{{ profile.full.department }}",
        'jobTitle' => "{{ profile.full.jobTitle }}",
        'phone' => "{{ profile.full.telephoneNumber }}"
],
```